### PR TITLE
Testing various browser arguments for dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack": "webpack",
     "server": "webpack && npm start",
+    "insecure-brave": "/Applications/Brave.app/Contents/MacOS/Brave  --enable-logging=stderr --apps-gallery-url=http://localhost:8080/store --apps-gallery-download-url='http://localhost/brave-extension-store:8080/%' --apps-gallery-update-url='http://localhost:8080/brave-extension-store/%' --show-app-list --allow-insecure-localhost --reduce-security-for-testing --user-data-dir=/tmp/insecure_brave_test  --unsafely-treat-insecure-origin-as-secure=http://localhost:8080/",
     "lint": "standard",
     "lintfix": "standard --fix"
   },

--- a/server.js
+++ b/server.js
@@ -10,9 +10,8 @@ var certOptions = {
 
 // Create a server with a host and port
 const server = Hapi.server({
-  host: 'example.com',
-  port: 443,
-  tls: certOptions
+  host: '127.0.0.1',
+  port: 8080,
 })
 
 let extensions = []


### PR DESCRIPTION
Hey through this together, curious if it does what your looking for. Wasn't sure the exact problem so kinda just through every arg that sounded like it might work on to `npm run insecure-brave`.


The path is hardcoded so you may have to make sure your running brave/brave-browser in /Applications