### PR TITLE
Use the default brave-browser-beta path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack": "webpack",
     "server": "webpack && npm start",
-    "insecure-brave": "/Applications/Brave.app/Contents/MacOS/Brave  --enable-logging=stderr --apps-gallery-url=http://localhost:8080/store --apps-gallery-download-url='http://localhost/brave-extension-store:8080/%' --apps-gallery-update-url='http://localhost:8080/brave-extension-store/%' --show-app-list --allow-insecure-localhost --reduce-security-for-testing --user-data-dir=/tmp/insecure_brave_test  --unsafely-treat-insecure-origin-as-secure=http://localhost:8080/",
+    "insecure-brave": "/Applications/Brave-Browser-Beta.app/Contents/MacOS/Brave  --enable-logging=stderr --apps-gallery-url=http://localhost:8080/store --apps-gallery-download-url='http://localhost:8080/brave-extension-store/%' --apps-gallery-update-url='http://localhost:8080/brave-extension-store/%' --show-app-list --allow-insecure-localhost --reduce-security-for-testing --user-data-dir=/tmp/insecure_brave_test  --unsafely-treat-insecure-origin-as-secure=http://localhost:8080/",
     "lint": "standard",
     "lintfix": "standard --fix"
   },


### PR DESCRIPTION
/Applications/Brave-Browser-Beta.app/Contents/MacOS/Brave is the default install path for https://github.com/brave/brave-browser-builds/releases on OSX.